### PR TITLE
Avoid usage of `ObjectCache::getMainWANInstance()`

### DIFF
--- a/includes/PortableInfobox.hooks.php
+++ b/includes/PortableInfobox.hooks.php
@@ -1,5 +1,7 @@
 <?php
 
+use MediaWiki\MediaWikiServices;
+
 // phpcs:ignore MediaWiki.Files.ClassMatchesFilename.NotMatch
 class PortableInfoboxHooks {
 
@@ -22,7 +24,7 @@ class PortableInfoboxHooks {
 	}
 
 	public static function onAllInfoboxesQueryRecached() {
-		$cache = ObjectCache::getMainWANInstance();
+		$cache = MediaWikiServices::getInstance()->getMainWANObjectCache();
 		$cache->delete( $cache->makeKey( ApiQueryAllinfoboxes::MCACHE_KEY ) );
 
 		return true;

--- a/includes/controllers/ApiQueryAllinfoboxes.php
+++ b/includes/controllers/ApiQueryAllinfoboxes.php
@@ -1,5 +1,7 @@
 <?php
 
+use MediaWiki\MediaWikiServices;
+
 class ApiQueryAllinfoboxes extends ApiQueryBase {
 
 	const CACHE_TTL = 86400;
@@ -8,7 +10,7 @@ class ApiQueryAllinfoboxes extends ApiQueryBase {
 	public function execute() {
 		$db = $this->getDB();
 		$res = $this->getResult();
-		$cache = ObjectCache::getMainWANInstance();
+		$cache = MediaWikiServices::getInstance()->getMainWANObjectCache();
 		$cachekey = $cache->makeKey( self::MCACHE_KEY );
 
 		$data = $cache->getWithSetCallback( $cachekey, self::CACHE_TTL, function () use ( $db ) {

--- a/includes/services/Helpers/PortableInfoboxTemplateEngine.php
+++ b/includes/services/Helpers/PortableInfoboxTemplateEngine.php
@@ -2,7 +2,9 @@
 
 namespace PortableInfobox\Helpers;
 
+use MediaWiki\MediaWikiServices;
 use MediaWiki\Logger\LoggerFactory;
+
 
 class PortableInfoboxTemplateEngine {
 	const CACHE_TTL = 86400;
@@ -29,7 +31,7 @@ class PortableInfoboxTemplateEngine {
 
 	public function __construct() {
 		if ( !isset( self::$memcache ) ) {
-			self::$memcache = \ObjectCache::getMainWANInstance();
+			self::$memcache = MediaWikiServices::getInstance()->getMainWANObjectCache();
 		}
 	}
 

--- a/includes/services/PortableInfoboxDataService.php
+++ b/includes/services/PortableInfoboxDataService.php
@@ -1,5 +1,6 @@
 <?php
 
+use MediaWiki\MediaWikiServices;
 use PortableInfobox\Helpers\PagePropsProxy;
 use PortableInfobox\Helpers\PortableInfoboxParsingHelper;
 use PortableInfobox\Parser\Nodes\NodeInfobox;
@@ -26,7 +27,7 @@ class PortableInfoboxDataService {
 		$this->title = $title !== null ? $title : new Title();
 		$this->parsingHelper = new PortableInfoboxParsingHelper();
 		$this->propsProxy = new PagePropsProxy();
-		$this->memcached = ObjectCache::getMainWANInstance();
+		$this->memcached = MediaWikiServices::getInstance()->getMainWANObjectCache();
 		$this->cachekey = $this->memcached->makeKey(
 			__CLASS__,
 			$this->title->getArticleID(),


### PR DESCRIPTION
ObjectCache::getMainWANInstance() has been removed under mediawiki 1.34+.