### PR TITLE
PortableInfoboxImagesHelper: Return empty array instead of false in PortableInfoboxImagesHelper

### DIFF
--- a/includes/services/Helpers/PortableInfoboxImagesHelper.php
+++ b/includes/services/Helpers/PortableInfoboxImagesHelper.php
@@ -19,7 +19,7 @@ class PortableInfoboxImagesHelper {
 		$file = $this->getFile( $file );
 
 		if ( !$file || !in_array( $file->getMediaType(), [ MEDIATYPE_BITMAP, MEDIATYPE_DRAWING ] ) ) {
-			return false;
+			return [];
 		}
 
 		// get dimensions
@@ -53,7 +53,7 @@ class PortableInfoboxImagesHelper {
 			'height' => round( $fileDimensions['height'] * $ratio * 2 ),
 		] );
 		if ( !$thumbnail || $thumbnail->isError() || !$thumbnail2x || $thumbnail2x->isError() ) {
-			return false;
+			return [];
 		}
 
 		return [


### PR DESCRIPTION
Because we use array_merge, the value returned has to be an array, not a boolean.

error message:

```ErrorException from line 166 of /srv/mediawiki/w/extensions/PortableInfobox/includes/services/Parser/Nodes/NodeMedia.php: PHP Warning: array_merge(): Expected parameter 2 to be an array, bool given```