### PR TITLE
Revert "Fix critical bug with LightnCandy"

### DIFF
--- a/includes/services/Helpers/PortableInfoboxTemplateEngine.php
+++ b/includes/services/Helpers/PortableInfoboxTemplateEngine.php
@@ -2,7 +2,6 @@
 
 namespace PortableInfobox\Helpers;
 
-use LightnCandy\LightnCandy;
 use MediaWiki\MediaWikiServices;
 use MediaWiki\Logger\LoggerFactory;
 
@@ -10,7 +9,7 @@ use MediaWiki\Logger\LoggerFactory;
 class PortableInfoboxTemplateEngine {
 	const CACHE_TTL = 86400;
 	const TYPE_NOT_SUPPORTED_MESSAGE = 'portable-infobox-render-not-supported-type';
-	const COMPILE_FLAGS = LightnCandy::FLAG_BESTPERFORMANCE | LightnCandy::FLAG_PARENT;
+	const COMPILE_FLAGS = \LightnCandy::FLAG_BESTPERFORMANCE | \LightnCandy::FLAG_PARENT;
 
 	private static $cache = [];
 	private static $memcache;
@@ -71,18 +70,18 @@ class PortableInfoboxTemplateEngine {
 				$template = self::$memcache->getWithSetCallback(
 					$cachekey, self::CACHE_TTL, function () use ( $path ) {
 						// @see https://github.com/wikimedia/mediawiki-vendor/tree/master/zordius/lightncandy
-						return LightnCandy::compile( file_get_contents( $path ), [
+						return \LightnCandy::compile( file_get_contents( $path ), [
 							'flags' => self::COMPILE_FLAGS
 						] );
 					}
 				);
 			} else {
-				$template = LightnCandy::compile( file_get_contents( $path ), [
+				$template = \LightnCandy::compile( file_get_contents( $path ), [
 					'flags' => self::COMPILE_FLAGS
 				] );
 			}
 
-			self::$cache[$type] = LightnCandy::prepare( $template );
+			self::$cache[$type] = \LightnCandy::prepare( $template );
 		}
 
 		return self::$cache[$type];


### PR DESCRIPTION
Reverts lkucharczyk/mediawiki-PortableInfobox#29

Causes:

2020-06-07 13:15:49 mw4 sagan4wiki: [e0e6ad56552b48ef3f25f2b6] /wiki/Gnarlpalm?useformat=mobile   Error from line 14 of /srv/mediawiki/w/extensions/PortableInfobox/includes/services/PortableInfoboxRenderService.php: Class 'LightnCandy\LightnCandy' not found


So reverting for now