### PR TITLE
Fix $text returning null within internalParse

### DIFF
--- a/includes/services/Parser/MediaWikiParserService.php
+++ b/includes/services/Parser/MediaWikiParserService.php
@@ -35,7 +35,7 @@ class MediaWikiParserService implements ExternalParser {
 			return $this->cache[$wikitext];
 		}
 
-		$parsed = $this->parser->internalParse( $wikitext, false, $this->frame );
+		$parsed = $wikitext ? $this->parser->internalParse( $wikitext, false, $this->frame ) : null;
 		if ( in_array( substr( $parsed, 0, 1 ), [ '*', '#' ] ) ) {
 			//fix for first item list elements
 			$parsed = "\n" . $parsed;


### PR DESCRIPTION
We don't use internalParse if $text returns null.

Otherwise this causes an error in the Translate extension:

 /w/index.php?title=Lucy_Stoole&veaction=edit&section=2&mobileaction=toggle_view_mobile   TypeError from line 23 of /srv/mediawiki/w/extensions/Translate/src/PageTranslation/TranslatablePageParser.php: Argument 1 passed to MediaWiki\Extensions\Translate\PageTranslation\TranslatablePageParser::containsMarkup() must be of the type string, null given, called in /srv/mediawiki/w/extensions/Translate/tag/PageTranslationHooks.php on line 50