### PR TITLE
Fix three fatal errors with MediaWiki 1.36.0+

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # mediawiki-PortableInfobox
-Port of FANDOM's https://github.com/Wikia/app/tree/dev/extensions/wikia/PortableInfobox extension to the MediaWiki 1.27+
+Port of FANDOM's https://github.com/Wikia/app/tree/dev/extensions/wikia/PortableInfobox extension to the MediaWiki 1.32+
 
 ## Installation
 Grab the latest release from [GitHub](https://github.com/Luqgreg/mediawiki-PortableInfobox/releases/latest) and unpack it into `extensions\PortableInfobox` directory in your MediaWiki installation or clone this repository, by using these commands:

--- a/extension.json
+++ b/extension.json
@@ -10,7 +10,7 @@
 	"type": "parserhook",
 	"license-name": "GPL-3.0-or-later",
 	"requires": {
-		"MediaWiki": ">= 1.27.0"
+		"MediaWiki": ">= 1.32.0"
 	},
 	"config": {
 		"AllInfoboxesSubpagesBlacklist": [ "doc", "draft", "test" ],

--- a/includes/services/Helpers/PortableInfoboxParsingHelper.php
+++ b/includes/services/Helpers/PortableInfoboxParsingHelper.php
@@ -3,6 +3,7 @@
 namespace PortableInfobox\Helpers;
 
 use MediaWiki\Logger\LoggerFactory;
+use MediaWiki\MediaWikiServices;
 
 class PortableInfoboxParsingHelper {
 
@@ -26,7 +27,7 @@ class PortableInfoboxParsingHelper {
 		$templateText = $this->fetchArticleContent( $title );
 
 		if ( $templateText ) {
-			$parser = new \Parser();
+			$parser = MediaWikiServices::getInstance()->getParser();
 			$parser->setTitle( $title );
 			$parserOptions = new \ParserOptions();
 			$frame = $parser->getPreprocessor()->newFrame();

--- a/includes/services/Parser/MediaWikiParserService.php
+++ b/includes/services/Parser/MediaWikiParserService.php
@@ -16,7 +16,14 @@ class MediaWikiParserService implements ExternalParser {
 		$this->frame = $frame;
 
 		if ( $wgPortableInfoboxUseTidy && class_exists( '\MediaWiki\Tidy\RemexDriver' ) ) {
-			$this->tidyDriver = MediaWiki\MediaWikiServices::getInstance()->getTidy();
+			if ( version_compare( MW_VERSION, '1.36', '>=' ) ) {
+				$this->tidyDriver = MediaWiki\MediaWikiServices::getInstance()->getTidy();
+			} else {
+				$this->tidyDriver = \MWTidy::factory( [
+					'driver' => 'RemexHtml',
+					'pwrap' => false
+				] );
+			}
 		}
 	}
 

--- a/includes/services/Parser/MediaWikiParserService.php
+++ b/includes/services/Parser/MediaWikiParserService.php
@@ -17,7 +17,7 @@ class MediaWikiParserService implements ExternalParser {
 
 		if ( $wgPortableInfoboxUseTidy && class_exists( '\MediaWiki\Tidy\RemexDriver' ) ) {
 			if ( version_compare( MW_VERSION, '1.36', '>=' ) ) {
-				$this->tidyDriver = MediaWiki\MediaWikiServices::getInstance()->getTidy();
+				$this->tidyDriver = \MediaWiki\MediaWikiServices::getInstance()->getTidy();
 			} else {
 				$this->tidyDriver = \MWTidy::factory( [
 					'driver' => 'RemexHtml',

--- a/includes/services/Parser/MediaWikiParserService.php
+++ b/includes/services/Parser/MediaWikiParserService.php
@@ -1,5 +1,8 @@
 <?php
+
 namespace PortableInfobox\Parser;
+
+use MediaWiki\MediaWikiServices;
 
 class MediaWikiParserService implements ExternalParser {
 
@@ -17,7 +20,7 @@ class MediaWikiParserService implements ExternalParser {
 
 		if ( $wgPortableInfoboxUseTidy && class_exists( '\MediaWiki\Tidy\RemexDriver' ) ) {
 			if ( version_compare( MW_VERSION, '1.36', '>=' ) ) {
-				$this->tidyDriver = \MediaWiki\MediaWikiServices::getInstance()->getTidy();
+				$this->tidyDriver = MediaWikiServices::getInstance()->getTidy();
 			} else {
 				$this->tidyDriver = \MWTidy::factory( [
 					'driver' => 'RemexHtml',

--- a/includes/services/Parser/MediaWikiParserService.php
+++ b/includes/services/Parser/MediaWikiParserService.php
@@ -16,10 +16,7 @@ class MediaWikiParserService implements ExternalParser {
 		$this->frame = $frame;
 
 		if ( $wgPortableInfoboxUseTidy && class_exists( '\MediaWiki\Tidy\RemexDriver' ) ) {
-			$this->tidyDriver = \MWTidy::factory( [
-				'driver' => 'RemexHtml',
-				'pwrap' => false
-			] );
+			$this->tidyDriver = MediaWiki\MediaWikiServices::getInstance()->getTidy();
 		}
 	}
 

--- a/includes/services/Parser/Nodes/NodeMedia.php
+++ b/includes/services/Parser/Nodes/NodeMedia.php
@@ -1,6 +1,8 @@
 <?php
+
 namespace PortableInfobox\Parser\Nodes;
 
+use MediaWiki\MediaWikiServices;
 use PortableInfobox\Helpers\FileNamespaceSanitizeHelper;
 use PortableInfobox\Helpers\PortableInfoboxDataBag;
 use PortableInfobox\Helpers\PortableInfoboxImagesHelper;
@@ -195,10 +197,11 @@ class NodeMedia extends Node {
 	}
 
 	private function getImageAsTitleObject( $imageName ) {
-		global $wgContLang;
+		$contLang = MediaWikiServices::getInstance()->getContentLanguage();
+
 		$title = \Title::makeTitleSafe(
 			NS_FILE,
-			FileNamespaceSanitizeHelper::getInstance()->sanitizeImageFileName( $imageName, $wgContLang )
+			FileNamespaceSanitizeHelper::getInstance()->sanitizeImageFileName( $imageName, $contLang )
 		);
 
 		return $title;


### PR DESCRIPTION
* MWTidy::factory no longer exists, therefore it gives fatal error, "Error: Call to undefined method MWTidy::factory()"
  * Maintains backward compatibility
* Too few arguments to function Parser::__construct(), 0 passed in extensions/PortableInfobox/includes/services/Helpers/PortableInfoboxParsingHelper.php on line 29 and exactly 16 expected
  * Maintains compatibility with MediaWiki 1.29+
* Replace `$wgContLang` which was removed on 1.36.
  * Mantains compatability with 1.32+; drops compatability with everything before that. I can fix it to maintain full compatability but I don't see the real need to.
 
  Also there is additional errors/warnings not fixed in this, such as:
  `
   ParserOptions being created without a UserIdentity object [Called from unknown in extensions/PortableInfobox/includes/services/Helpers/PortableInfoboxParsingHelper.php at line 31] in includes/debug/MWDebug.php on line 376
 `